### PR TITLE
Add XML section reader and factory for spaCy inputs

### DIFF
--- a/src/peer_elt/parse/__init__.py
+++ b/src/peer_elt/parse/__init__.py
@@ -3,6 +3,12 @@
 from peer_elt.parse.models import ArticleDocument, GrobidResult, LayoutBlock, ParsedDocument
 from peer_elt.parse.pipeline import ArticleParsingPipeline, PdfParsingPipeline
 from peer_elt.parse.processors import SimpleTokenStatsProcessor
+from peer_elt.parse.xml_reader import (
+    SectionTagExtractor,
+    TeiSectionExtractor,
+    XmlSectionReader,
+    XmlSectionReaderFactory,
+)
 
 __all__ = [
     "ArticleDocument",
@@ -12,4 +18,8 @@ __all__ = [
     "ParsedDocument",
     "PdfParsingPipeline",
     "SimpleTokenStatsProcessor",
+    "SectionTagExtractor",
+    "TeiSectionExtractor",
+    "XmlSectionReader",
+    "XmlSectionReaderFactory",
 ]

--- a/src/peer_elt/parse/xml_reader.py
+++ b/src/peer_elt/parse/xml_reader.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+"""XML readers and extractors for spaCy-ready section text.
+
+This module provides a small XML reading abstraction that turns XML documents
+into ``Mapping[str, str]`` payloads that can be fed into ``SpacyProcessor``
+implementations. The design uses the Strategy pattern to allow multiple XML
+flavors (e.g., TEI vs. custom section tags) and a simple Factory for
+constructing readers by format name.
+"""
+
+from dataclasses import dataclass, field
+from typing import Mapping, Protocol
+from xml.etree import ElementTree
+
+
+class XmlSectionExtractor(Protocol):
+    """Strategy interface for extracting section text from XML."""
+
+    def extract_sections(self, root: ElementTree.Element) -> Mapping[str, str]:
+        """Extract section text from an XML root."""
+
+
+def _collapse_whitespace(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class SectionTagExtractor(XmlSectionExtractor):
+    """Extract sections from XML using a dedicated section tag.
+
+    Parameters
+    ----------
+    section_tag : str, default="section"
+        Tag name to treat as a section container.
+    name_attribute : str, default="name"
+        Attribute name that stores the section label.
+    """
+
+    section_tag: str = "section"
+    name_attribute: str = "name"
+
+    def extract_sections(self, root: ElementTree.Element) -> Mapping[str, str]:
+        sections: dict[str, str] = {}
+        for section in root.iter(self.section_tag):
+            name = section.attrib.get(self.name_attribute)
+            if not name:
+                continue
+            text = _collapse_whitespace(" ".join(section.itertext()))
+            if text:
+                sections[name] = text
+        return sections
+
+
+@dataclass(frozen=True)
+class TeiSectionExtractor(XmlSectionExtractor):
+    """Extract sections from TEI-like XML.
+
+    This implementation uses ``div`` elements as section containers. It
+    prefers the ``type`` attribute as a section name and falls back to a
+    ``head`` element if present.
+    """
+
+    div_tag: str = "div"
+    type_attribute: str = "type"
+    head_tag: str = "head"
+
+    def extract_sections(self, root: ElementTree.Element) -> Mapping[str, str]:
+        sections: dict[str, str] = {}
+        for div in root.iter(self.div_tag):
+            name = div.attrib.get(self.type_attribute)
+            if not name:
+                head = div.find(self.head_tag)
+                if head is not None:
+                    name = _collapse_whitespace(" ".join(head.itertext()))
+            if not name:
+                continue
+            text = _collapse_whitespace(" ".join(div.itertext()))
+            if text:
+                sections[name] = text
+        return sections
+
+
+@dataclass(frozen=True)
+class XmlSectionReader:
+    """Parse XML text into spaCy-ready section mappings."""
+
+    extractor: XmlSectionExtractor
+
+    def read(self, xml: str) -> Mapping[str, str]:
+        try:
+            root = ElementTree.fromstring(xml)
+        except ElementTree.ParseError as exc:
+            raise ValueError("Invalid XML payload.") from exc
+        return self.extractor.extract_sections(root)
+
+
+@dataclass(frozen=True)
+class XmlSectionReaderFactory:
+    """Factory for creating XML readers by format name."""
+
+    registry: Mapping[str, XmlSectionExtractor] = field(
+        default_factory=lambda: {
+            "section-tag": SectionTagExtractor(),
+            "tei": TeiSectionExtractor(),
+        }
+    )
+
+    def create(self, format_name: str) -> XmlSectionReader:
+        try:
+            extractor = self.registry[format_name]
+        except KeyError as exc:
+            raise ValueError(f"Unknown XML format: {format_name}") from exc
+        return XmlSectionReader(extractor=extractor)
+
+
+__all__ = [
+    "SectionTagExtractor",
+    "TeiSectionExtractor",
+    "XmlSectionExtractor",
+    "XmlSectionReader",
+    "XmlSectionReaderFactory",
+]

--- a/tests/test_xml_reader.py
+++ b/tests/test_xml_reader.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import pytest
+
+from peer_elt.parse.xml_reader import (
+    SectionTagExtractor,
+    TeiSectionExtractor,
+    XmlSectionReader,
+    XmlSectionReaderFactory,
+)
+
+
+def test_section_tag_reader_extracts_named_sections() -> None:
+    xml = """
+    <document>
+        <section name="methods"><p>Some methods.</p></section>
+        <section name="results"><p>Good results.</p></section>
+    </document>
+    """
+
+    reader = XmlSectionReader(extractor=SectionTagExtractor())
+
+    assert reader.read(xml) == {
+        "methods": "Some methods.",
+        "results": "Good results.",
+    }
+
+
+def test_tei_reader_prefers_type_attribute_and_falls_back_to_head() -> None:
+    xml = """
+    <TEI>
+        <text>
+            <body>
+                <div type="methods"><p>First.</p><p>Second.</p></div>
+                <div><head>Conclusion</head><p>Done.</p></div>
+            </body>
+        </text>
+    </TEI>
+    """
+
+    reader = XmlSectionReader(extractor=TeiSectionExtractor())
+
+    assert reader.read(xml) == {
+        "methods": "First. Second.",
+        "Conclusion": "Conclusion Done.",
+    }
+
+
+def test_reader_factory_handles_formats_and_rejects_unknown() -> None:
+    factory = XmlSectionReaderFactory()
+
+    reader = factory.create("tei")
+
+    assert isinstance(reader.extractor, TeiSectionExtractor)
+    with pytest.raises(ValueError, match="Unknown XML format"):
+        factory.create("unknown-format")
+
+
+def test_reader_raises_on_invalid_xml() -> None:
+    reader = XmlSectionReader(extractor=SectionTagExtractor())
+
+    with pytest.raises(ValueError, match="Invalid XML"):
+        reader.read("<document><section>")


### PR DESCRIPTION
### Motivation
- Provide a reusable XML reader that converts XML documents into spaCy-ready section mappings to support TEI and other XML flavors.
- Use design patterns (Strategy + Factory) so different XML extraction strategies can be swapped or extended without changing pipeline code.
- Enable TDD by adding targeted unit tests that drive the XML-reading behavior and error handling.

### Description
- Add `src/peer_elt/parse/xml_reader.py` implementing `XmlSectionReader`, `XmlSectionReaderFactory`, and two extractor strategies `SectionTagExtractor` and `TeiSectionExtractor` using the Strategy pattern.
- Normalize whitespace and extract section labels and texts from `section` tags or TEI-style `div`/`head` elements, with robust parse error handling that raises `ValueError` on invalid XML.
- Expose the new utilities from the `peer_elt.parse` package by updating `src/peer_elt/parse/__init__.py` to include `SectionTagExtractor`, `TeiSectionExtractor`, `XmlSectionReader`, and `XmlSectionReaderFactory`.
- Add unit tests in `tests/test_xml_reader.py` covering section-tag extraction, TEI `type` / `head` fallback behavior, factory selection, and invalid XML handling.

### Testing
- Ran the full test suite with `pytest -q` and the run completed successfully with all tests passing.
- Added tests `tests/test_xml_reader.py` which validate `SectionTagExtractor`, `TeiSectionExtractor`, `XmlSectionReader`, and `XmlSectionReaderFactory` and they pass under CI-local test run.
- Existing parsing pipeline tests were re-run as part of `pytest` and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987904a99f483239c1357a0d2fc6b8d)